### PR TITLE
Deduplication mechanism and testing

### DIFF
--- a/backend/internal/collector/kubernetes.go
+++ b/backend/internal/collector/kubernetes.go
@@ -15,12 +15,13 @@ import (
 )
 
 type KubernetesCollector struct {
-	clientset      kubernetes.Interface
-	kubeConfigPath string
-	namespaces     []string
-	requireAnnot   bool
-	allowedSources []string
-	lastProcessed  map[string]int64 // map["ns/name"]generation
+	clientset        kubernetes.Interface
+	kubeConfigPath   string
+	namespaces       []string
+	requireAnnot     bool
+	allowedSources   []string
+	lastProcessed    map[string]int64    // map["ns/name"]generation
+	lastProcessedSha map[string]string // map["ns/name"]fingerprint
 }
 
 func NewKubernetesCollector(cfg config.Config, clientset kubernetes.Interface) (*KubernetesCollector, error) {
@@ -45,12 +46,13 @@ func NewKubernetesCollector(cfg config.Config, clientset kubernetes.Interface) (
 	}
 
 	return &KubernetesCollector{
-		clientset:      clientset,
-		kubeConfigPath: cfg.Kubernetes.KubeConfigPath,
-		namespaces:     cfg.Kubernetes.Namespaces,
-		requireAnnot:   cfg.Kubernetes.RequireAnnotation,
-		allowedSources: cfg.Kubernetes.AllowedSources,
-		lastProcessed:  make(map[string]int64),
+		clientset:        clientset,
+		kubeConfigPath:   cfg.Kubernetes.KubeConfigPath,
+		namespaces:       cfg.Kubernetes.Namespaces,
+		requireAnnot:     cfg.Kubernetes.RequireAnnotation,
+		allowedSources:   cfg.Kubernetes.AllowedSources,
+		lastProcessed:    make(map[string]int64),
+		lastProcessedSha: make(map[string]string),
 	}, nil
 }
 
@@ -59,19 +61,19 @@ func (c *KubernetesCollector) Start(ctx context.Context, eventChan chan<- domain
 	defer ticker.Stop()
 
 	// Initial run
-	c.collectAndSend(ctx, eventChan)
+	c.CollectAndSend(ctx, eventChan)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			c.collectAndSend(ctx, eventChan)
+			c.CollectAndSend(ctx, eventChan)
 		}
 	}
 }
 
-func (c *KubernetesCollector) collectAndSend(ctx context.Context, eventChan chan<- domain.ChangeEvent) {
+func (c *KubernetesCollector) CollectAndSend(ctx context.Context, eventChan chan<- domain.ChangeEvent) {
 	allDeps, err := c.clientset.AppsV1().Deployments("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		fmt.Printf("Error listing deployments: %v\n", err)
@@ -95,9 +97,22 @@ func (c *KubernetesCollector) collectAndSend(ctx context.Context, eventChan chan
 			continue
 		}
 
-		// Deduplicate
+		// Deduplicate based on generation
 		if gen, ok := c.lastProcessed[key]; ok && gen >= d.Generation {
 			continue
+		}
+
+		// Deduplicate based on fingerprint
+		gitSha := d.Annotations["valiant.io/git-sha"]
+		if gitSha == "" {
+			gitSha = d.Annotations["kubernetes.io/change-cause"]
+		}
+		if gitSha != "" {
+			if lastSha, ok := c.lastProcessedSha[key]; ok && lastSha == gitSha {
+				fmt.Printf("Ignored rollout: deployment %s generation changed but fingerprint %s is the same\n", key, gitSha)
+				c.lastProcessed[key] = d.Generation // Update generation to prevent re-evaluating
+				continue
+			}
 		}
 
 		// 1. Intent Validation
@@ -120,15 +135,15 @@ func (c *KubernetesCollector) collectAndSend(ctx context.Context, eventChan chan
 			}
 		}
 
-		if availableCond == nil || availableCond.Status != "True" || 
-		   progressingCond == nil || progressingCond.Reason != "NewReplicaSetAvailable" {
+		if availableCond == nil || availableCond.Status != "True" ||
+			progressingCond == nil || progressingCond.Reason != "NewReplicaSetAvailable" {
 			continue
 		}
 
 		// 3. Timing & Metadata
 		if time.Since(availableCond.LastUpdateTime.Time) < 35*time.Second {
 			rolloutStartTime := d.CreationTimestamp.Time
-			
+
 			var rsSelector string
 			if d.Spec.Selector != nil {
 				rsSelector = metav1.FormatLabelSelector(d.Spec.Selector)
@@ -151,25 +166,20 @@ func (c *KubernetesCollector) collectAndSend(ctx context.Context, eventChan chan
 			}
 
 			rolloutEndTime := availableCond.LastUpdateTime.Time
-			gitSha := d.Annotations["valiant.io/git-sha"]
-			if gitSha == "" {
-				gitSha = d.Annotations["kubernetes.io/change-cause"]
-			}
-
 			image := ""
 			if len(d.Spec.Template.Spec.Containers) > 0 {
 				image = d.Spec.Template.Spec.Containers[0].Image
 			}
 
 			eventChan <- domain.ChangeEvent{
-				ID:          fmt.Sprintf("k8s-%s-%s-%d", d.Namespace, d.Name, d.Generation),
-				TriggerType: "GitOps",
-				ExecutionID: fmt.Sprintf("%s-%d", d.UID, d.Generation),
-				ChangeType:  "deployment_rollout",
-				Timestamp:   rolloutStartTime,
-				EndTime:     &rolloutEndTime,
+				ID:               fmt.Sprintf("k8s-%s-%s-%d", d.Namespace, d.Name, d.Generation),
+				TriggerType:      "GitOps",
+				ExecutionID:      fmt.Sprintf("%s-%d", d.UID, d.Generation),
+				ChangeType:       "deployment_rollout",
+				Timestamp:        rolloutStartTime,
+				EndTime:          &rolloutEndTime,
 				AffectedServices: []string{d.Name},
-				Summary:     fmt.Sprintf("Deployment %s rollout completed via %s", d.Name, source),
+				Summary:          fmt.Sprintf("Deployment %s rollout completed via %s", d.Name, source),
 				Metadata: map[string]string{
 					"namespace":     d.Namespace,
 					"kind":          "Deployment",
@@ -182,6 +192,9 @@ func (c *KubernetesCollector) collectAndSend(ctx context.Context, eventChan chan
 				},
 			}
 			c.lastProcessed[key] = d.Generation
+			if gitSha != "" {
+				c.lastProcessedSha[key] = gitSha
+			}
 		}
 	}
 }

--- a/backend/internal/collector/kubernetes_test.go
+++ b/backend/internal/collector/kubernetes_test.go
@@ -2,6 +2,7 @@ package collector_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 	"valiant/internal/collector"
@@ -59,12 +60,8 @@ func TestKubernetesCollector_AuditorLogic(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	// In a test, we can call the internal method directly if we make it public or 
-	// just run Start and wait for events.
-	// Since I made Start public, I'll run it in a goroutine.
 	go coll.Start(ctx, eventChan)
 
-	// Wait for one event (intentional-app)
 	select {
 	case event := <-eventChan:
 		if event.AffectedServices[0] != "intentional-app" {
@@ -74,15 +71,121 @@ func TestKubernetesCollector_AuditorLogic(t *testing.T) {
 		t.Error("timeout waiting for event")
 	}
 
-	// Verify no more events (manual-app should be ignored)
 	select {
 	case event := <-eventChan:
 		t.Errorf("unexpected second event: %s", event.Summary)
 	default:
-		// Success: no more events
 	}
 }
 
-// More advanced K8s tests would require mocking the clientset entirely
-// which NewKubernetesCollector doesn't currently support (it creates its own).
-// Refactoring NewKubernetesCollector to accept a clientset interface would improve testability.
+func newTestDeployment(name string, generation int64, sha string, available bool) *appsv1.Deployment {
+	annotations := map[string]string{
+		"valiant.io/source": "argocd",
+	}
+	if sha != "" {
+		annotations["valiant.io/git-sha"] = sha
+	}
+
+	conditions := []appsv1.DeploymentCondition{}
+	if available {
+		conditions = append(conditions, appsv1.DeploymentCondition{
+			Type:           "Available",
+			Status:         "True",
+			LastUpdateTime: metav1.Now(),
+		})
+		conditions = append(conditions, appsv1.DeploymentCondition{
+			Type:   "Progressing",
+			Reason: "NewReplicaSetAvailable",
+		})
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Annotations: annotations,
+			Generation:  generation,
+			UID:         "test-uid",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: conditions,
+		},
+	}
+}
+
+func TestKubernetesCollector_FingerprintDeduplication(t *testing.T) {
+	cfg := config.Config{}
+	cfg.Kubernetes.RequireAnnotation = true
+	cfg.Kubernetes.AllowedSources = []string{"argocd"}
+
+	client := fake.NewSimpleClientset()
+	coll, err := collector.NewKubernetesCollector(cfg, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventChan := make(chan domain.ChangeEvent, 10)
+	ctx := context.Background()
+
+	expectEvent := func(shouldExist bool, expectedGen int64, step string) {
+		t.Helper()
+		select {
+		case event := <-eventChan:
+			if !shouldExist {
+				t.Fatalf("[%s] unexpected event for generation %s", step, event.Metadata["generation"])
+			}
+			genStr := event.Metadata["generation"]
+			if genStr != fmt.Sprintf("%d", expectedGen) {
+				t.Errorf("[%s] expected event for generation %d, got %s", step, expectedGen, genStr)
+			}
+		case <-time.After(100 * time.Millisecond):
+			if shouldExist {
+				t.Fatalf("[%s] timeout waiting for event for generation %d", step, expectedGen)
+			}
+		}
+	}
+
+	// 2. Initial deploy (gen 1, sha A) -> SHOULD collect
+	dep := newTestDeployment("app-a", 1, "sha-a", true)
+	if _, err := client.AppsV1().Deployments("default").Create(ctx, dep, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	coll.CollectAndSend(ctx, eventChan)
+	expectEvent(true, 1, "Initial Deploy")
+
+	// 3. Metadata change (gen 2, sha A) -> SHOULD IGNORE
+	dep.Generation = 2
+	dep.ResourceVersion = "2" 
+	if _, err := client.AppsV1().Deployments("default").Update(ctx, dep, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	coll.CollectAndSend(ctx, eventChan)
+	expectEvent(false, 2, "Metadata Change")
+
+	// 4. New code (gen 3, sha B) -> SHOULD collect
+	dep.Generation = 3
+	dep.ResourceVersion = "3"
+	dep.Annotations["valiant.io/git-sha"] = "sha-b"
+	if _, err := client.AppsV1().Deployments("default").Update(ctx, dep, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	coll.CollectAndSend(ctx, eventChan)
+	expectEvent(true, 3, "New Code")
+
+	// 5. Rollback (gen 4, sha A) -> SHOULD collect
+	dep.Generation = 4
+	dep.ResourceVersion = "4"
+	dep.Annotations["valiant.io/git-sha"] = "sha-a"
+	if _, err := client.AppsV1().Deployments("default").Update(ctx, dep, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	coll.CollectAndSend(ctx, eventChan)
+	expectEvent(true, 4, "Rollback")
+
+	// 6. No change (gen 4, sha A) -> SHOULD IGNORE (by generation check)
+	dep.ResourceVersion = "5"
+	if _, err := client.AppsV1().Deployments("default").Update(ctx, dep, metav1.UpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	coll.CollectAndSend(ctx, eventChan)
+	expectEvent(false, 4, "No Change")
+}


### PR DESCRIPTION
**Description**
Enhances the Kubernetes collector to reduce noise by ignoring deployment rollouts where only metadata changes, using the valiant.io/git-sha fingerprint for deduplication.

**Changes Made**
 - Implemented fingerprint-based rollout deduplication in the Kubernetes collector.
 - Improved collector testability by exporting the CollectAndSend method.
 - Added a new unit test for fingerprint deduplication logic.

**Testing Done**
 - New test case TestKubernetesCollector_FingerprepreintDeduplication
 - All unit tests passed, confirming the new deduplication functionality.

**Related Issues**                                                                                                                                                                                                                                                     
Fixes #12  