### PR TITLE
Added Heuristic linking of Intent and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initialized Valiant project structure.
 - **Backend (Go):**
   - Implemented **Orphan Event Detection**: Execution events (e.g., GitOps, manual) without a corresponding intent event (e.g., CI) within a configurable correlation window are now marked as `IsOrphaned`.
+  - **Intent-Execution Linking**: Implemented backend logic to link CI (Intent) and GitOps/manual (Execution) events using `git_sha` or `image_tag` within a configurable `intent_execution_correlation_window`. This replaces the previous `IsOrphaned` check based solely on services.
+  - Extended `PostgresStorage.GetChangeEvents` to support filtering by metadata content (`git_sha` or `image_tag`).
+  - Renamed `OrphanCorrelationWindow` to `IntentExecutionCorrelationWindow` in configuration for clarity.
   - Extended `PostgresStorage.GetChangeEvents` to support filtering by trigger type, time range, and affected services.
   - Added `IsOrphaned` field to `domain.ImpactAnalysis` for API response.
   - Added `OrphanCorrelationWindow` configuration to `config.yaml`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Valiant solves a critical problem for engineering teams: quickly identifying the
 
 To use Valiant effectively, it helps to understand these key principles and the analysis flow:
 
-- A **ChangeEvent** represents when a change becomes *effective* in an environment (e.g., a deployment finishes), not when it was committed to source control.
+- A **ChangeEvent** represents when a change becomes *effective* in an environment (e.g., a deployment finishes), not when it was committed to source control. It differentiates between **Intent** (e.g., a CI build) and **Execution** (e.g., a GitOps deployment) events, which can be linked based on shared metadata like Git SHAs or image tags.
 - An **Impact Analysis** is an immutable, reproducible snapshot. An analysis performed today will yield the exact same result a year from now.
 - **Correlation** is scoped to explicit, rule-based time windows (a "baseline" before the change and an "impact" window after). It is never inferred or predictive.
 
@@ -51,6 +51,7 @@ Valiant fits into the observability landscape by providing a focused, determinis
 ## Features
 
 - **Change Collection**: Ingests change events from various sources, including Kubernetes (deployments, configmaps, secrets), and generic CI/CD webhooks.
+- **Intent-Execution Linking**: Automatically correlates CI (Intent) and GitOps/manual (Execution) events using shared metadata (Git SHAs, image tags) within a configurable time window, providing a clearer picture of the change lineage.
 - **Core Correlation Engine**: Implements a complete, deterministic impact scoring and ranking logic to link changes to service degradation.
 - **Single Environment Support**: The Open Source (OSS) version is designed to target a single Kubernetes cluster and Prometheus instance.
 - **Manual Analysis**: All correlation analyses are user-initiated via the UI or API, providing on-demand insights.

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -26,8 +26,8 @@ type Config struct {
 		ImpactWindow   string        `yaml:"post_execution_impact_window"`
 		BaselineDur    time.Duration `yaml:"-"`
 		ImpactDur             time.Duration `yaml:"-"`
-		OrphanCorrelationWindow string        `yaml:"orphan_correlation_window"`
-		OrphanCorrelationDur  time.Duration `yaml:"-"`
+		IntentExecutionCorrelationWindow string        `yaml:"intent_execution_correlation_window"`
+		IntentExecutionCorrelationDur  time.Duration `yaml:"-"`
 	} `yaml:"analysis"`
 }
 
@@ -47,7 +47,7 @@ func Load(configPath string) (*Config, error) {
 	}
 	cfg.Analysis.BaselineWindow = "30m"
 	cfg.Analysis.ImpactWindow = "30m"
-	cfg.Analysis.OrphanCorrelationWindow = "1h"
+	cfg.Analysis.IntentExecutionCorrelationWindow = "1h"
 
 	// Load from YAML if exists, potentially overriding defaults
 	if configPath != "" {
@@ -74,9 +74,9 @@ func Load(configPath string) (*Config, error) {
 		cfg.Analysis.ImpactDur = 30 * time.Minute
 	}
 
-	cfg.Analysis.OrphanCorrelationDur, err = time.ParseDuration(cfg.Analysis.OrphanCorrelationWindow)
+	cfg.Analysis.IntentExecutionCorrelationDur, err = time.ParseDuration(cfg.Analysis.IntentExecutionCorrelationWindow)
 	if err != nil {
-		cfg.Analysis.OrphanCorrelationDur = 1 * time.Hour
+		cfg.Analysis.IntentExecutionCorrelationDur = 1 * time.Hour
 	}
 
 	return cfg, nil

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -41,7 +41,7 @@ port: "7070"
 analysis:
   baseline_window: "15m"
   post_execution_impact_window: "1h"
-  orphan_correlation_window: "2h"
+  intent_execution_correlation_window: "2h"
 `
 	tmpFile := "test_config.yaml"
 	err := os.WriteFile(tmpFile, []byte(yamlContent), 0644)
@@ -64,8 +64,8 @@ analysis:
 	if cfg.Analysis.ImpactDur != 1*time.Hour {
 		t.Errorf("expected impact 1h, got %v", cfg.Analysis.ImpactDur)
 	}
-	if cfg.Analysis.OrphanCorrelationDur != 2*time.Hour {
-		t.Errorf("expected orphan correlation 2h, got %v", cfg.Analysis.OrphanCorrelationDur)
+	if cfg.Analysis.IntentExecutionCorrelationDur != 2*time.Hour {
+		t.Errorf("expected orphan correlation 2h, got %v", cfg.Analysis.IntentExecutionCorrelationDur)
 	}
 }
 

--- a/backend/internal/correlator/engine.go
+++ b/backend/internal/correlator/engine.go
@@ -58,24 +58,36 @@ func (e *Engine) AnalyzeImpact(ctx context.Context, event domain.ChangeEvent) (d
 		ChangeEvent: event,
 	}
 
-	// 2. Orphan detection
+	// 2. Intent/Execution Linking (formerly Orphan Detection)
 	isExecutionEvent := event.TriggerType == "GitOps" || event.TriggerType == "manual"
-	if isExecutionEvent {
-		// Look for a corresponding CI event in the correlation window
-		from := event.Timestamp.Add(-e.config.Analysis.OrphanCorrelationDur)
+	if isExecutionEvent && (event.Metadata["git_commit_sha"] != "" || event.Metadata["image_tag"] != "") {
+		// This is an execution event with linking metadata. Look for a corresponding CI event.
+		from := event.Timestamp.Add(-e.config.Analysis.IntentExecutionCorrelationDur)
 		to := event.Timestamp
+		
+		metadataToLink := make(map[string]string)
+		if sha, ok := event.Metadata["git_commit_sha"]; ok && sha != "" {
+			metadataToLink["git_commit_sha"] = sha
+		}
+		if tag, ok := event.Metadata["image_tag"]; ok && tag != "" {
+			metadataToLink["image_tag"] = tag
+		}
+
 		ciEvents, err := e.storage.GetChangeEvents(ctx, map[string]interface{}{
-			"trigger_type":    "CI",
-			"from_timestamp":  from,
-			"to_timestamp":    to,
-			"services_any_of": event.AffectedServices,
+			"trigger_type":     "CI",
+			"from_timestamp":   from,
+			"to_timestamp":     to,
+			"metadata_has_any": metadataToLink,
 		})
 		if err != nil {
-			return domain.ImpactAnalysis{}, fmt.Errorf("failed to check for orphan event: %w", err)
+			return domain.ImpactAnalysis{}, fmt.Errorf("failed to check for corresponding CI event: %w", err)
 		}
 		if len(ciEvents) == 0 {
 			analysis.IsOrphaned = true
 		}
+	} else if isExecutionEvent {
+		// Fallback for execution events without linking metadata
+		analysis.IsOrphaned = true
 	}
 
 	// 3. Define time windows relative to the change event using Config

--- a/backend/internal/correlator/engine_linking_test.go
+++ b/backend/internal/correlator/engine_linking_test.go
@@ -1,0 +1,322 @@
+package correlator_test
+
+import (
+	"context"
+	"testing"
+	"time"
+	"valiant/internal/config"
+	"valiant/internal/correlator"
+	"valiant/internal/domain"
+)
+
+// LinkingMockStorage implements storage.Storage for linking tests
+type LinkingMockStorage struct {
+	// All possible events the mock can return
+	availableChangeEvents []domain.ChangeEvent
+	// Filters that were applied in the last call to GetChangeEvents
+	filtersApplied map[string]interface{}
+}
+
+func (m *LinkingMockStorage) SaveChangeEvent(ctx context.Context, event domain.ChangeEvent) error { return nil }
+func (m *LinkingMockStorage) GetChangeEvents(ctx context.Context, filters map[string]interface{}) ([]domain.ChangeEvent, error) {
+	m.filtersApplied = filters
+	var results []domain.ChangeEvent
+
+	from, fromOk := filters["from_timestamp"].(time.Time)
+	to, toOk := filters["to_timestamp"].(time.Time)
+
+	for _, event := range m.availableChangeEvents {
+		// Basic time filtering
+		if fromOk && event.Timestamp.Before(from) {
+			continue
+		}
+		if toOk && event.Timestamp.After(to) {
+			continue
+		}
+		// Basic trigger type filtering
+		if triggerType, ok := filters["trigger_type"]; ok && event.TriggerType != triggerType {
+			continue
+		}
+		// Basic metadata filtering
+		if metadataFilter, ok := filters["metadata_has_any"].(map[string]string); ok {
+			match := false
+			for key, value := range metadataFilter {
+				if event.Metadata[key] == value {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		results = append(results, event)
+	}
+
+	return results, nil
+}
+func (m *LinkingMockStorage) GetChangeEventByID(ctx context.Context, id string) (domain.ChangeEvent, error) {
+	return domain.ChangeEvent{}, nil
+}
+func (m *LinkingMockStorage) GetServices(ctx context.Context) ([]string, error) { return nil, nil }
+func (m *LinkingMockStorage) GetEventsPendingAnalysis(ctx context.Context) ([]domain.ChangeEvent, error) {
+	return nil, nil
+}
+func (m *LinkingMockStorage) SaveImpactAnalysis(ctx context.Context, analysis domain.ImpactAnalysis) error { return nil }
+func (m *LinkingMockStorage) GetImpactAnalysisByEventID(ctx context.Context, eventID string) (*domain.ImpactAnalysis, error) {
+	return nil, nil
+}
+
+
+func TestIntentExecutionLinking(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Analysis.IntentExecutionCorrelationDur = 1 * time.Hour
+	metrics := &ControllableMetrics{Calls: []domain.MetricValues{{}, {}}} // Dummy metrics
+	eventTime := time.Now().Add(-2 * time.Hour)
+
+	baseExecutionEvent := domain.ChangeEvent{
+		ID:          "exec-evt-1",
+		TriggerType: "GitOps",
+		Timestamp:   eventTime,
+		Metadata:    map[string]string{"git_commit_sha": "abcdef123"},
+	}
+
+	t.Run("Successful Link via git_sha", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				{ID: "ci-evt-1", TriggerType: "CI", Timestamp: eventTime.Add(-10 * time.Minute), Metadata: map[string]string{"git_commit_sha": "abcdef123"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		analysis, err := engine.AnalyzeImpact(context.Background(), baseExecutionEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false, but it was true")
+		}
+		
+		metadataFilter := store.filtersApplied["metadata_has_any"].(map[string]string)
+		if metadataFilter["git_commit_sha"] != "abcdef123" {
+			t.Errorf("Incorrect git_commit_sha in metadata filter")
+		}
+	})
+	
+	t.Run("Successful Link via image_tag", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				{ID: "ci-evt-2", TriggerType: "CI", Timestamp: eventTime.Add(-10 * time.Minute), Metadata: map[string]string{"image_tag": "v1.2.3"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "exec-evt-2",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"image_tag": "v1.2.3"},
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false, but it was true")
+		}
+	})
+	
+	t.Run("Successful Link with both sha and tag", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				// This one matches the sha
+				{ID: "ci-evt-sha", TriggerType: "CI", Timestamp: eventTime.Add(-10 * time.Minute), Metadata: map[string]string{"git_commit_sha": "abcdef123"}},
+				// This one is irrelevant
+				{ID: "ci-evt-other", TriggerType: "CI", Timestamp: eventTime.Add(-11 * time.Minute), Metadata: map[string]string{"git_commit_sha": "other"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "exec-evt-3",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"git_commit_sha": "abcdef123", "image_tag": "v1.2.3"},
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false, but it was true")
+		}
+		// The mock should have found one event.
+	})
+
+	t.Run("Orphaned when no matching CI event exists", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		analysis, err := engine.AnalyzeImpact(context.Background(), baseExecutionEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be true, but it was false")
+		}
+	})
+	
+	t.Run("Successful link at the very edge of the time window", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				// This CI event is exactly at the boundary of the 1-hour window
+				{ID: "ci-evt-edge", TriggerType: "CI", Timestamp: eventTime.Add(-1 * time.Hour), Metadata: map[string]string{"git_commit_sha": "abcdef123"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		analysis, err := engine.AnalyzeImpact(context.Background(), baseExecutionEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false when CI event is at the window edge, but it was true")
+		}
+	})
+	
+	t.Run("Orphaned when CI event is just outside the time window", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				// This CI event is 1 second outside the 1-hour window
+				{ID: "ci-evt-outside", TriggerType: "CI", Timestamp: eventTime.Add(-1 * time.Hour).Add(-1 * time.Second), Metadata: map[string]string{"git_commit_sha": "abcdef123"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		analysis, err := engine.AnalyzeImpact(context.Background(), baseExecutionEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be true when CI event is outside the window, but it was false")
+		}
+	})
+
+	t.Run("Orphaned when execution event has no linking metadata", func(t *testing.T) {
+		store := &LinkingMockStorage{}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "exec-evt-nometa",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{}, // No SHA or tag
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if !analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be true for event with no linking metadata, but it was false")
+		}
+	})
+	
+	t.Run("Non-execution event is never orphaned", func(t *testing.T) {
+		store := &LinkingMockStorage{}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "ci-evt-only",
+			TriggerType: "CI",
+			Timestamp:   eventTime,
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false for a non-execution event, but it was true")
+		}
+	})
+
+	t.Run("Multiple executions link to the same CI event", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				{ID: "ci-evt-multi", TriggerType: "CI", Timestamp: eventTime.Add(-10 * time.Minute), Metadata: map[string]string{"image_tag": "v3.0.0"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+
+		// First execution event
+		execEvent1 := domain.ChangeEvent{
+			ID:          "exec-evt-multi-1",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"image_tag": "v3.0.0"},
+		}
+		analysis1, err := engine.AnalyzeImpact(context.Background(), execEvent1)
+		if err != nil {
+			t.Fatalf("Unexpected error on first event: %v", err)
+		}
+		if analysis1.IsOrphaned {
+			t.Error("Expected first execution event not to be orphaned, but it was")
+		}
+
+		// Second execution event, slightly later
+		execEvent2 := domain.ChangeEvent{
+			ID:          "exec-evt-multi-2",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime.Add(5 * time.Minute),
+			Metadata:    map[string]string{"image_tag": "v3.0.0"},
+		}
+		analysis2, err := engine.AnalyzeImpact(context.Background(), execEvent2)
+		if err != nil {
+			t.Fatalf("Unexpected error on second event: %v", err)
+		}
+		if analysis2.IsOrphaned {
+			t.Error("Expected second execution event not to be orphaned, but it was")
+		}
+	})
+
+	t.Run("Orphaned when CI event is missing linking metadata", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				// This CI event corresponds in time, but has no metadata to link by
+				{ID: "ci-evt-no-meta", TriggerType: "CI", Timestamp: eventTime.Add(-10 * time.Minute), Metadata: map[string]string{}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		analysis, err := engine.AnalyzeImpact(context.Background(), baseExecutionEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be true when CI event is missing metadata, but it was false")
+		}
+	})
+
+	t.Run("Linkable manual event is not orphaned", func(t *testing.T) {
+		store := &LinkingMockStorage{
+			availableChangeEvents: []domain.ChangeEvent{
+				{ID: "ci-evt-manual", TriggerType: "CI", Timestamp: eventTime.Add(-5 * time.Minute), Metadata: map[string]string{"git_commit_sha": "manual-sha"}},
+			},
+		}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		manualEvent := domain.ChangeEvent{
+			ID:          "manual-exec-1",
+			TriggerType: "manual",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"git_commit_sha": "manual-sha"},
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), manualEvent)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if analysis.IsOrphaned {
+			t.Error("Expected linkable manual event not to be orphaned, but it was")
+		}
+	})
+}
+

--- a/backend/internal/correlator/engine_test.go
+++ b/backend/internal/correlator/engine_test.go
@@ -304,157 +304,102 @@ func TestAnalyzeImpact_InstantRollout(t *testing.T) {
 	}
 }
 
-func TestAnalyzeImpact_OrphanEvent(t *testing.T) {
+func TestAnalyzeImpact_IntentExecutionLinking(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Analysis.OrphanCorrelationDur = 1 * time.Hour
-	// Metrics will be called for baseline/impact, so provide dummy values
-	metrics := &ControllableMetrics{
-		Calls: []domain.MetricValues{{}, {}},
-	}
-	eventTime := time.Now().Add(-2 * time.Hour) // Far enough in past
+	cfg.Analysis.IntentExecutionCorrelationDur = 1 * time.Hour
+	metrics := &ControllableMetrics{Calls: []domain.MetricValues{{}, {}}}
+	eventTime := time.Now().Add(-2 * time.Hour)
 
-	// --- SCENARIO 1: Is Orphaned ---
-	t.Run("IsOrphaned", func(t *testing.T) {
+	t.Run("Linked GitOps event", func(t *testing.T) {
 		store := &MockStorage{
-			changeEvents: []domain.ChangeEvent{}, // No corresponding CI event
-		}
-		engine := correlator.NewEngine(store, metrics, cfg)
-		event := domain.ChangeEvent{
-			ID:               "evt-orphan",
-			Timestamp:        eventTime,
-			TriggerType:      "GitOps",
-			AffectedServices: []string{"service-a"},
-		}
-
-		analysis, err := engine.AnalyzeImpact(context.Background(), event)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if !analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be true, but it was false")
-		}
-	})
-
-	// --- SCENARIO 2: Not Orphaned ---
-	t.Run("NotOrphaned", func(t *testing.T) {
-		store := &MockStorage{
-			changeEvents: []domain.ChangeEvent{ // Found a matching CI event
-				{ID: "evt-ci-match", TriggerType: "CI"},
+			changeEvents: []domain.ChangeEvent{
+				{ID: "ci-evt-1", TriggerType: "CI", Metadata: map[string]string{"git_commit_sha": "abcdef123"}},
 			},
 		}
 		engine := correlator.NewEngine(store, metrics, cfg)
 		event := domain.ChangeEvent{
-			ID:               "evt-not-orphan",
-			Timestamp:        eventTime,
-			TriggerType:      "GitOps",
-			AffectedServices: []string{"service-a"},
+			ID:          "exec-evt-1",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"git_commit_sha": "abcdef123"},
 		}
-
 		analysis, err := engine.AnalyzeImpact(context.Background(), event)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
-
 		if analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be false, but it was true")
+			t.Error("Expected IsOrphaned to be false, but it was true")
 		}
 	})
 
-	// --- SCENARIO 3: Non-execution events are never orphaned ---
-	t.Run("NeverOrphanedForCI", func(t *testing.T) {
-		store := &MockStorage{
-			changeEvents: []domain.ChangeEvent{}, // No other events exist
-		}
+	t.Run("Orphaned GitOps event (no match)", func(t *testing.T) {
+		store := &MockStorage{changeEvents: []domain.ChangeEvent{}}
 		engine := correlator.NewEngine(store, metrics, cfg)
 		event := domain.ChangeEvent{
-			ID:               "evt-ci-never-orphan",
-			Timestamp:        eventTime,
-			TriggerType:      "CI", // This is not an execution event
-			AffectedServices: []string{"service-a"},
+			ID:          "exec-evt-2",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{"git_commit_sha": "abcdef123"},
 		}
-
 		analysis, err := engine.AnalyzeImpact(context.Background(), event)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
-
-		if analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be false for a CI event, but it was true")
-		}
-	})
-
-	// --- SCENARIO 4: Match at the edge of the window ---
-	t.Run("MatchAtWindowEdge", func(t *testing.T) {
-		store := &MockStorage{
-			// The GetChangeEvents mock in the real implementation would handle the time filtering,
-			// for this test, we simulate that it *does* return an event that is precisely on the boundary.
-			changeEvents: []domain.ChangeEvent{{ID: "evt-ci-edge", TriggerType: "CI"}},
-		}
-		engine := correlator.NewEngine(store, metrics, cfg)
-		event := domain.ChangeEvent{
-			ID:               "evt-edge-case",
-			Timestamp:        eventTime,
-			TriggerType:      "GitOps",
-			AffectedServices: []string{"service-a"},
-		}
-
-		analysis, err := engine.AnalyzeImpact(context.Background(), event)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be false when match is at window edge, but it was true")
-		}
-	})
-
-	// --- SCENARIO 5: No match just outside the window ---
-	t.Run("NoMatchOutsideWindow", func(t *testing.T) {
-		store := &MockStorage{
-			// Simulate that the storage query found no events in the window.
-			changeEvents: []domain.ChangeEvent{},
-		}
-		engine := correlator.NewEngine(store, metrics, cfg)
-		event := domain.ChangeEvent{
-			ID:               "evt-outside-window",
-			Timestamp:        eventTime,
-			TriggerType:      "GitOps",
-			AffectedServices: []string{"service-a"},
-		}
-
-		analysis, err := engine.AnalyzeImpact(context.Background(), event)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
 		if !analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be true when match is outside window, but it was false")
+			t.Error("Expected IsOrphaned to be true, but it was false")
 		}
 	})
 
-	// --- SCENARIO 6: Orphaned when services do not overlap ---
-	t.Run("OrphanedWithMismatchedServices", func(t *testing.T) {
-		store := &MockStorage{
-			// Storage returns a CI event, but the correlator's filter *should* have excluded it.
-			// We simulate this by having the mock return an empty list.
-			changeEvents: []domain.ChangeEvent{},
-		}
+	t.Run("Orphaned GitOps event (no metadata)", func(t *testing.T) {
+		store := &MockStorage{}
 		engine := correlator.NewEngine(store, metrics, cfg)
 		event := domain.ChangeEvent{
-			ID:               "evt-mismatched-svc",
-			Timestamp:        eventTime,
-			TriggerType:      "GitOps",
-			AffectedServices: []string{"service-a"},
+			ID:          "exec-evt-3",
+			TriggerType: "GitOps",
+			Timestamp:   eventTime,
+			Metadata:    map[string]string{},
 		}
-
 		analysis, err := engine.AnalyzeImpact(context.Background(), event)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("Unexpected error: %v", err)
 		}
-
 		if !analysis.IsOrphaned {
-			t.Error("expected IsOrphaned to be true when services do not match, but it was false")
+			t.Error("Expected IsOrphaned to be true for event with no linking metadata, but it was false")
+		}
+	})
+
+	t.Run("Orphaned manual event", func(t *testing.T) {
+		store := &MockStorage{}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "manual-evt-1",
+			TriggerType: "manual",
+			Timestamp:   eventTime,
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be true for manual event, but it was false")
+		}
+	})
+
+	t.Run("CI event is never orphaned", func(t *testing.T) {
+		store := &MockStorage{}
+		engine := correlator.NewEngine(store, metrics, cfg)
+		event := domain.ChangeEvent{
+			ID:          "ci-evt-only",
+			TriggerType: "CI",
+			Timestamp:   eventTime,
+		}
+		analysis, err := engine.AnalyzeImpact(context.Background(), event)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if analysis.IsOrphaned {
+			t.Error("Expected IsOrphaned to be false for a CI event, but it was true")
 		}
 	})
 }
+

--- a/backend/internal/storage/postgres.go
+++ b/backend/internal/storage/postgres.go
@@ -98,6 +98,17 @@ func (s *PostgresStorage) GetChangeEvents(ctx context.Context, filters map[strin
 		args = append(args, to)
 		argCount++
 	}
+	if metadata, ok := filters["metadata_has_any"].(map[string]string); ok && len(metadata) > 0 {
+		var metadataClauses []string
+		for key, value := range metadata {
+			metadataClauses = append(metadataClauses, fmt.Sprintf("metadata @> $%d", argCount))
+			jsonFilter := fmt.Sprintf(`{"%s": "%s"}`, key, value)
+			args = append(args, jsonFilter)
+			argCount++
+		}
+		whereClauses = append(whereClauses, "("+strings.Join(metadataClauses, " OR ")+")")
+	}
+
 	if services, ok := filters["services_any_of"].([]string); ok && len(services) > 0 {
 		whereClauses = append(whereClauses, fmt.Sprintf("affected_services && $%d", argCount))
 		args = append(args, pq.Array(services))

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -61,4 +61,4 @@ analysis:
 
   # Duration to look back from an execution event to find a corresponding intent (CI) event.
   # If no intent event is found within this window, the execution event is marked as orphaned.
-  orphan_correlation_window: "1h"
+  intent_execution_correlation_window: "1h"


### PR DESCRIPTION
Description:
This PR introduces Intent-Execution Linking, a significant enhancement to Valiant's change analysis. It kinda replaces basic orphan detection with a robust system to explicitly connect execution events (e.g., GitOps deployments) with their originating intent (e.g.,
CI builds) using shared Git SHAs or image tags. This provides a clearer, traceable lineage of changes in the Valiant timeline, highlighting whether a deployment was part of a planned, validated release or an unexpected deviation.

Changes Made:
 - Core Linking Logic: Refactored engine.go to link execution events to CI intents via git_sha or image_tag within a configurable window.
 - Config Clarity: Renamed OrphanCorrelationWindow to IntentExecutionCorrelationWindow in config.go.
 - DB Query Enhancement: Extended PostgresStorage.GetChangeEvents to filter by metadata content (git_sha, image_tag).
 - Refined Orphan Detection: Improved logic for marking execution events as orphaned (e.g., no matching intent, missing metadata, or handling linkable manual events).

Testing Done:
 - Extensive Unit Tests: Added engine_linking_test.go covering successful links, various orphan scenarios, time window edge cases, multiple links to one intent, CI metadata issues, and manual event linking.
 - Existing Tests Updated: Adapted engine_test.go to the new linking logic.
 - Full Test Suite Pass: All tests pass, confirming functionality and stability.

Related Issues:
Fixes #9