### PR TITLE
feat(frontend): display application version in footer

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import Footer from "@/components/footer";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +17,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <div className="flex flex-col min-h-screen">
+          <div className="flex-1">{children}</div>
+          <Footer />
+        </div>
+      </body>
     </html>
   );
 }

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -17,11 +17,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
-        <div className="flex flex-col min-h-screen">
-          <div className="flex-1">{children}</div>
-          <Footer />
+      <body className={`${inter.className} min-h-screen flex flex-col`}>
+        <div className="flex-1">
+          {children}
         </div>
+        <Footer />
       </body>
     </html>
   );

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,0 +1,11 @@
+import packageJson from '@/package.json';
+
+export default function Footer() {
+  return (
+    <footer className="bg-white border-t border-gray-100 py-4 px-8 text-center">
+      <p className="text-xs text-gray-400">
+        Valiant v{packageJson.version}
+      </p>
+    </footer>
+  );
+}


### PR DESCRIPTION
### What
Adds a small, unobtrusive application version label (`Valiant v0.1.0`) to the UI footer.

### Why
This allows users and developers to quickly identify the running version without impacting the UI or layout.

### How
- Reads the version from `package.json` as a single source of truth
- Adds a minimal footer component rendered via `RootLayout`
- Uses subtle Tailwind styling
- Ensures valid HTML structure by avoiding nested `<main>` landmarks

No functional or visual changes beyond the version label.